### PR TITLE
MCC-331992 reduce test output size

### DIFF
--- a/XCSummary/Parser/JSONTestResultParser.m
+++ b/XCSummary/Parser/JSONTestResultParser.m
@@ -14,7 +14,7 @@
     NSDictionary *testInformation;
 }
 
-- (instancetype)initWithFilePath:(NSString *)path {    
+- (instancetype)initWithFilePath:(NSString *)path {
     self = [super init];
     
     if (self) {

--- a/XCSummary/Templates/CMHTMLReportBuilder.h
+++ b/XCSummary/Templates/CMHTMLReportBuilder.h
@@ -22,7 +22,8 @@
 - (instancetype)initWithAttachmentsPath:(NSString *)path
                             resultsPath:(NSString *)resultsPath
                   testInformationParser:(JSONTestResultParser *)testInformationParser
-                       showSuccessTests:(BOOL)showSuccessTests;
+                       showSuccessTests:(BOOL)showSuccessTests
+                     excludedTestBundle:(NSString *)excludedTestBundle;
 
 /**
  Appends summaries info as a header

--- a/XCSummary/Templates/CMHTMLReportBuilder.m
+++ b/XCSummary/Templates/CMHTMLReportBuilder.m
@@ -154,10 +154,10 @@
 - (void)_appendActivities:(NSArray *)activities indentation:(CGFloat)indentation
 {
     [activities enumerateObjectsUsingBlock:^(CMActivitySummary * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-        if (![obj.title isEqualToString:@"Synthesize event"]) {
-            [self _appendActivity:obj indentation:indentation];
-        }
-
+        if ([obj.title isEqualToString:@"Synthesize event"])
+            return;
+        
+        [self _appendActivity:obj indentation:indentation];
         [self _appendActivities:obj.subActivities indentation:indentation + 50];
     }];
 }

--- a/XCSummary/Templates/CMHTMLReportBuilder.m
+++ b/XCSummary/Templates/CMHTMLReportBuilder.m
@@ -23,6 +23,7 @@
 @property (nonatomic, strong) NSMutableString *resultString;
 @property (nonatomic, strong) NSFileManager *fileManager;
 @property (nonatomic) BOOL showSuccessTests;
+@property (nonatomic, strong) NSString *excludedTestBundle;
 
 @property (nonatomic, strong) NSDateComponentsFormatter *timeFormatter;
 
@@ -36,6 +37,7 @@
                             resultsPath:(NSString *)resultsPath
                   testInformationParser:(JSONTestResultParser *)testInformationParser
                        showSuccessTests:(BOOL)showSuccessTests
+                      excludedTestBundle:(NSString *)excludedTestBundle
 {
     self = [super init];
     if (self)
@@ -47,6 +49,7 @@
         _resultString = [NSMutableString new];
         _showSuccessTests = showSuccessTests;
         _testParser = testInformationParser;
+        _excludedTestBundle = excludedTestBundle;
         [self _prepareResourceFolder];
     }
     return self;
@@ -81,9 +84,19 @@
 
 - (void)appendTests:(NSArray *)tests indentation:(CGFloat)indentation
 {
+
     [tests enumerateObjectsUsingBlock:^(CMTest * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-        
+
+        // Exclude the specified test bundle (e.g. UnitTests.xctest)
+        if ([obj.testName isEqualToString:@"All tests"]) {
+            CMTest *firstTest = obj.subTests.firstObject;
+
+            if ([[firstTest testName] isEqualToString:_excludedTestBundle])
+                return;
+        }
+
         [self _appendTestCase:obj indentation:indentation];
+        
         if (obj.subTests.count > 0)
         {
             [self appendTests:obj.subTests indentation:indentation + 50];
@@ -141,7 +154,10 @@
 - (void)_appendActivities:(NSArray *)activities indentation:(CGFloat)indentation
 {
     [activities enumerateObjectsUsingBlock:^(CMActivitySummary * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-        [self _appendActivity:obj indentation:indentation];
+        if (![obj.title isEqualToString:@"Synthesize event"]) {
+            [self _appendActivity:obj indentation:indentation];
+        }
+
         [self _appendActivities:obj.subActivities indentation:indentation + 50];
     }];
 }

--- a/XCSummary/main.m
+++ b/XCSummary/main.m
@@ -32,6 +32,8 @@ int main(int argc, const char * argv[]) {
             return EXIT_FAILURE;
         }
         
+        NSString *excludeBundle = CMSummaryGetValue(arguments, @"-exclude");
+        
         NSString *summaryPath = [input stringByExpandingTildeInPath];
         NSString *attachmentsPath = [[summaryPath stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"Attachments"];
         
@@ -47,7 +49,8 @@ int main(int argc, const char * argv[]) {
         CMHTMLReportBuilder *builder = [[CMHTMLReportBuilder alloc] initWithAttachmentsPath:attachmentsPath
                                                                                 resultsPath:output.stringByExpandingTildeInPath
                                                                       testInformationParser:testInformationParser
-                                                                           showSuccessTests:showSuccess];
+                                                                           showSuccessTests:showSuccess
+                                                                         excludedTestBundle:excludeBundle];
         [builder appendSummaries:summaries];
         [summaries enumerateObjectsUsingBlock:^(CMTestableSummary *summary, NSUInteger idx, BOOL * _Nonnull stop) {
             [builder appendTests:summary.tests indentation:10.0f];


### PR DESCRIPTION
This PR does two things to reduce the size of our test output.

1. Skips activities with the 'Synthesize Event' title, which seem superfluous. These generally happen when we're looking to see that an element exists. However, we don't need screenshots for that because earlier / later screenshots that actually navigate us to the page will have the expected screenshot. This makes a big difference because if we check 10 different labels on a screen, we might end up with 10 of the same screenshot attached to different 'Synthesize Event' activities
2. Adds an 'exclude' command line option where we can exclude a specific test bundle. In this case we'll use it to remove 'UnitTests.xctest'

With these changes our zipped test output is about 930MB.